### PR TITLE
fix typo, function names and deprecated warnings

### DIFF
--- a/h6x_internship_gazebo/CMakeLists.txt
+++ b/h6x_internship_gazebo/CMakeLists.txt
@@ -22,7 +22,7 @@ ament_auto_add_library(gazebo_ros_target_point SHARED
 # ===================================================================
 
 # executable (judge) ================================================
-ament_auto_add_executable(judge_courceout src/judge/judge_courseout.cpp)
+ament_auto_add_executable(judge_deviation src/judge/judge_deviation.cpp)
 ament_auto_add_executable(game_master src/judge/game_master.cpp)
 ament_auto_add_executable(judge_goal src/judge/judge_goal.cpp)
 # ===================================================================

--- a/h6x_internship_gazebo/launch/world.launch.py
+++ b/h6x_internship_gazebo/launch/world.launch.py
@@ -15,7 +15,6 @@
 
 import os
 
-import paramiko
 
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
@@ -61,10 +60,10 @@ def generate_launch_description():
             '-d', os.path.join(pkg_line_trace, 'rviz', 'line_trace.rviz')]
     )
 
-    judge_courceout = Node(
+    judge_deviation = Node(
         package='h6x_internship_gazebo',
-        executable='judge_courseout',
-        name='judge_courceout'
+        executable='judge_deviation',
+        name='judge_deviation'
     )
 
     judge_goal = Node(
@@ -87,8 +86,7 @@ def generate_launch_description():
         # gzclient_cmd,
         joint_state_publisher_node,
         rviz,
-
-        judge_courceout,
+        judge_deviation,
         judge_goal,
         game_master,
     ])

--- a/h6x_internship_gazebo/src/diff_drive_controller_plugin.hpp
+++ b/h6x_internship_gazebo/src/diff_drive_controller_plugin.hpp
@@ -46,9 +46,9 @@ public:
   void Reset() override;
   void OnUpdate();
 
-  void twistCallback(const geometry_msgs::msg::Twist & msg);
+  void onTwist(const geometry_msgs::msg::Twist & msg);
 
-  void sub_speedlimit_callback(const std_msgs::msg::Float32 & msg);
+  void onSpeedLimit(const std_msgs::msg::Float32 & msg);
 
 private:
   gazebo::physics::ModelPtr model_;
@@ -59,8 +59,8 @@ private:
   gazebo_ros::Node::SharedPtr ros_node_;
 
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_sub_;
-  rclcpp::Subscription<std_msgs::msg::Float32>::SharedPtr sub_speedlimit_;
+  rclcpp::Subscription<std_msgs::msg::Float32>::SharedPtr sub_speed_limit_;
 
   geometry_msgs::msg::Twist last_cmd_vel_;
 };
-} // end namespace gazebo_plugins
+}  // end namespace gazebo_plugins

--- a/h6x_internship_gazebo/src/gazebo_ros_target_point.cpp
+++ b/h6x_internship_gazebo/src/gazebo_ros_target_point.cpp
@@ -12,111 +12,114 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <boost/make_shared.hpp>
-#include <boost/variant.hpp>
 #include <gazebo/transport/transport.hh>
-#include "gazebo_ros_target_point.hpp"
-#include <gazebo_ros/conversions/sensor_msgs.hpp>
-#include <gazebo_ros/node.hpp>
-#include <gazebo_ros/utils.hpp>
-#include <rclcpp/rclcpp.hpp>
-
-#include <std_msgs/msg/bool.hpp>
-
 #include <string>
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <boost/make_shared.hpp>
+#include <boost/variant.hpp>
+#include <gazebo_ros/conversions/sensor_msgs.hpp>
+#include <gazebo_ros/node.hpp>
+#include <gazebo_ros/utils.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include "gazebo_ros_target_point.hpp"
+
+#include <std_msgs/msg/bool.hpp>
+
 namespace goal_plugin
 {
 
-  class GazeboRosTargetPointPrivate
-  {
-  public:
-    /// Node for ROS communication.
-    gazebo_ros::Node::SharedPtr ros_node_;
+class GazeboRosTargetPointPrivate
+{
+public:
+  /// Node for ROS communication.
+  gazebo_ros::Node::SharedPtr ros_node_;
 
-    using GoaledPub = rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr;
-    boost::variant<GoaledPub> pub_;
+  using GoaledPub = rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr;
+  boost::variant<GoaledPub> pub_;
 
-    std::string frame_name_;
+  std::string frame_name_;
 
-    /// Subscribe to gazebo's laserscan, calling the appropriate callback based on output type
-    void SubscribeGazeboLaserScan();
-    void PublishGoaled(ConstLaserScanStampedPtr &_msg);
+  /// Subscribe to gazebo's laser scan,
+  // calling the appropriate callback based on output type
+  void SubscribeGazeboLaserScan();
+  void PublishGoaled(const ConstLaserScanStampedPtr & _msg);
 
-    std::string sensor_topic_;
+  std::string sensor_topic_;
 
-    // double min_intensity_{0.0};
+  // double min_intensity_{0.0};
 
-    gazebo::transport::NodePtr gazebo_node_;
-    gazebo::transport::SubscriberPtr laser_scan_sub_;
-  };
+  gazebo::transport::NodePtr gazebo_node_;
+  gazebo::transport::SubscriberPtr laser_scan_sub_;
+};
 
-  GazeboRosTargetPoint::GazeboRosTargetPoint()
-      : impl_(std::make_unique<GazeboRosTargetPointPrivate>())
-  {
+GazeboRosTargetPoint::GazeboRosTargetPoint()
+: impl_(std::make_unique<GazeboRosTargetPointPrivate>())
+{
+}
+
+GazeboRosTargetPoint::~GazeboRosTargetPoint()
+{
+  // Must release subscriber and then call
+  // fini on node to remove it from topic manager.
+  impl_->laser_scan_sub_.reset();
+  if (impl_->gazebo_node_) {
+    impl_->gazebo_node_->Fini();
+  }
+  impl_->gazebo_node_.reset();
+}
+
+void GazeboRosTargetPoint::Load(
+  gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _sdf)
+{
+  // Create ros_node configured from sdf
+  impl_->ros_node_ = gazebo_ros::Node::Get(_sdf);
+
+  // Get QoS profiles
+  const gazebo_ros::QoS & qos = impl_->ros_node_->get_qos();
+
+  // Get QoS profile for the publisher
+  rclcpp::QoS pub_qos =
+    qos.get_publisher_qos("~/out", rclcpp::SensorDataQoS().reliable());
+
+  // Get tf frame for output
+  impl_->frame_name_ = gazebo_ros::SensorFrameID(*_sensor, *_sdf);
+
+  // Get output type from sdf if provided
+  impl_->pub_ =
+    impl_->ros_node_->create_publisher<std_msgs::msg::Bool>("~/out", pub_qos);
+  // Create gazebo transport node and subscribe to sensor's laser scan
+  impl_->gazebo_node_ = boost::make_shared<gazebo::transport::Node>();
+  impl_->gazebo_node_->Init(_sensor->WorldName());
+
+  impl_->sensor_topic_ = _sensor->Topic();
+  impl_->SubscribeGazeboLaserScan();
+}
+
+void GazeboRosTargetPointPrivate::SubscribeGazeboLaserScan()
+{
+  laser_scan_sub_ = gazebo_node_->Subscribe(
+    sensor_topic_, &GazeboRosTargetPointPrivate::PublishGoaled, this);
+}
+
+void GazeboRosTargetPointPrivate::PublishGoaled(ConstLaserScanStampedPtr & _msg)
+{
+  // Convert Laser scan to range
+  auto range_msg = gazebo_ros::Convert<sensor_msgs::msg::Range>(*_msg);
+  bool is_goal = false;
+  float touch_distance = 1.0;
+  std_msgs::msg::Bool goaled_msg;
+
+  if (range_msg.range < touch_distance) {
+    is_goal = true;
   }
 
-  GazeboRosTargetPoint::~GazeboRosTargetPoint()
-  {
-    // Must release subscriber and then call fini on node to remove it from topic manager.
-    impl_->laser_scan_sub_.reset();
-    if (impl_->gazebo_node_)
-    {
-      impl_->gazebo_node_->Fini();
-    }
-    impl_->gazebo_node_.reset();
-  }
+  goaled_msg.data = is_goal;
+  boost::get<GoaledPub>(pub_)->publish(goaled_msg);
+}
 
-  void GazeboRosTargetPoint::Load(gazebo::sensors::SensorPtr _sensor, sdf::ElementPtr _sdf)
-  {
-    // Create ros_node configured from sdf
-    impl_->ros_node_ = gazebo_ros::Node::Get(_sdf);
+// Register this plugin with the simulator
+GZ_REGISTER_SENSOR_PLUGIN(GazeboRosTargetPoint)
 
-    // Get QoS profiles
-    const gazebo_ros::QoS &qos = impl_->ros_node_->get_qos();
-
-    // Get QoS profile for the publisher
-    rclcpp::QoS pub_qos = qos.get_publisher_qos("~/out", rclcpp::SensorDataQoS().reliable());
-
-    // Get tf frame for output
-    impl_->frame_name_ = gazebo_ros::SensorFrameID(*_sensor, *_sdf);
-
-    // Get output type from sdf if provided
-    impl_->pub_ = impl_->ros_node_->create_publisher<std_msgs::msg::Bool>("~/out", pub_qos);
-    // Create gazebo transport node and subscribe to sensor's laser scan
-    impl_->gazebo_node_ = boost::make_shared<gazebo::transport::Node>();
-    impl_->gazebo_node_->Init(_sensor->WorldName());
-
-    impl_->sensor_topic_ = _sensor->Topic();
-    impl_->SubscribeGazeboLaserScan();
-  }
-
-  void GazeboRosTargetPointPrivate::SubscribeGazeboLaserScan()
-  {
-    laser_scan_sub_ = gazebo_node_->Subscribe(
-        sensor_topic_, &GazeboRosTargetPointPrivate::PublishGoaled, this);
-  }
-
-  void GazeboRosTargetPointPrivate::PublishGoaled(ConstLaserScanStampedPtr &_msg)
-  {
-    // Convert Laser scan to range
-    auto range_msg = gazebo_ros::Convert<sensor_msgs::msg::Range>(*_msg);
-    bool is_goal = false;
-    float touch_distance = 1.0;
-    std_msgs::msg::Bool goaled_msg;
-
-    if (range_msg.range < touch_distance)
-    {
-      is_goal = true;
-    }
-
-    goaled_msg.data = is_goal;
-    boost::get<GoaledPub>(pub_)->publish(goaled_msg);
-  }
-
-  // Register this plugin with the simulator
-  GZ_REGISTER_SENSOR_PLUGIN(GazeboRosTargetPoint)
-
-} // namespace goal_plugin
+}  // namespace goal_plugin

--- a/h6x_internship_gazebo/src/gazebo_ros_target_point.hpp
+++ b/h6x_internship_gazebo/src/gazebo_ros_target_point.hpp
@@ -37,4 +37,4 @@ private:
   std::unique_ptr<GazeboRosTargetPointPrivate> impl_;
 };
 
-}
+}  // namespace goal_plugin

--- a/h6x_internship_gazebo/src/judge/game_define.hpp
+++ b/h6x_internship_gazebo/src/judge/game_define.hpp
@@ -18,7 +18,7 @@
 #define START 1
 #define GOAL 2
 
-#define GAMEOVER_SCORE 1000
+#define GAME_OVER_SCORE 1000
 
 #define DEBUG 10
 #define INFO 20

--- a/h6x_internship_gazebo/src/judge/game_master.hpp
+++ b/h6x_internship_gazebo/src/judge/game_master.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <string>
 #include <rclcpp/rclcpp.hpp>
 #include <rcl_interfaces/msg/log.hpp>
 #include <std_msgs/msg/bool.hpp>
@@ -27,26 +28,26 @@ class GameMaster : public rclcpp::Node
 public:
   GameMaster();
 
-  void courseout_count_callback(const std_msgs::msg::Int32::SharedPtr ptr);
-  void status_callback(const std_msgs::msg::Int32::SharedPtr ptr);
+  void onDeviationCount(const std_msgs::msg::Int32::SharedPtr ptr);
+  void onStatus(const std_msgs::msg::Int32::SharedPtr ptr);
 
-  void timer_count_update();
-  void score_update_and_publish();
+  void timerCountUpdate();
+  void scoreUpdateAndPublish();
 
-  void game_master_status();
-  void game_master_time();
-  void game_master_score();
+  void gameMasterStatus();
+  void gameMasterTime();
+  void gameMasterScore();
 
-  void publish_viecle_status();
+  void publishVehicleStatus();
 
 private:
-  rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr sub_courseout_;
+  rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr sub_deviation_;
 
   // 3 state --------------------------------------------------
   rclcpp::Subscription<std_msgs::msg::Int32>::SharedPtr sub_status_;
 
-  // courseout --------------------------------------------------
-  rclcpp::Subscription<std_msgs::msg::Int32>::SharedPtr sub_courseout_count_;
+  // deviation ------------------------------------------------
+  rclcpp::Subscription<std_msgs::msg::Int32>::SharedPtr sub_deviation_count_;
 
   rclcpp::Subscription<std_msgs::msg::Int32>::SharedPtr sub_charge_;
 
@@ -59,23 +60,24 @@ private:
   rclcpp::TimerBase::SharedPtr timer_;
 
   int64_t game_status_;
-  bool gameover_was_sent_;
+  bool game_over_was_sent_;
 
   bool tmp_charge_flag_;
 
-  // courseout --------------------------------------------------
+  // deviation ------------------------------------------------
   int64_t count_;
-  int64_t gameover_socre_;
+  int64_t game_over_score_;
 
-  int64_t tmp_courseout_count_;
-  int64_t courseout_count_;
+  int64_t tmp_deviation_count_;
+  int64_t deviation_count_;
 
   int64_t past_time_;
   int64_t score_;
   int64_t charge_score_;
 
-  int64_t viecle_status_;
-  float speed_limit_;   // for viecle speed limit (normal: 1.0, slow: 0.5, fast: 2.0, stop: 0.0)
+  int64_t vehicle_status_;
+  // for vehicle speed limit (normal: 1.0, slow: 0.5, fast: 2.0, stop: 0.0)
+  float speed_limit_;
 
   std::string prefix_;
 };

--- a/h6x_internship_gazebo/src/judge/judge_deviation.cpp
+++ b/h6x_internship_gazebo/src/judge/judge_deviation.cpp
@@ -12,20 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "judge_courseout.hpp"
+#include "judge_deviation.hpp"
 
-JudgeCourseout::JudgeCourseout()
-: Node("judge_courseout")
+JudgeDeviation::JudgeDeviation()
+: Node("judge_deviation")
 {
   rmw_qos_profile_t qos_sensor = rmw_qos_profile_sensor_data;
   this->sub_image_ = image_transport::create_subscription(
     this, "/camera_linetrace/camera1/image_raw",
-    std::bind(&JudgeCourseout::image_callback, this, std::placeholders::_1), "raw", qos_sensor);
+    std::bind(
+      &JudgeDeviation::onImage, this, std::placeholders::_1),
+    "raw", qos_sensor);
 
-  data_pub_ = this->create_publisher<std_msgs::msg::Bool>("/judge_courseout/data", 10);
+  data_pub_ =
+    this->create_publisher<std_msgs::msg::Bool>("/judge_deviation/data", 10);
 }
 
-void JudgeCourseout::image_callback(const sensor_msgs::msg::Image::ConstSharedPtr & ptr)
+void JudgeDeviation::onImage(
+  const sensor_msgs::msg::Image::ConstSharedPtr & ptr)
 {
   cv_bridge::CvImagePtr cv_ptr;
   std_msgs::msg::Bool msg_data;
@@ -44,7 +48,7 @@ void JudgeCourseout::image_callback(const sensor_msgs::msg::Image::ConstSharedPt
   cv::cvtColor(frame, gray, cv::COLOR_BGR2GRAY);
   // 0 ~ 100 : ok
   // width = 100, height = 1
-  unsigned short int black_count = 0;
+  int black_count = 0;
   for (int i = 0; i < gray.cols; i++) {
     if (gray.at<uchar>(0, i) < 100) {
       black_count++;
@@ -62,7 +66,7 @@ void JudgeCourseout::image_callback(const sensor_msgs::msg::Image::ConstSharedPt
 int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
-  auto node = std::make_shared<JudgeCourseout>();
+  auto node = std::make_shared<JudgeDeviation>();
   rclcpp::spin(node);
   rclcpp::shutdown();
   return 0;

--- a/h6x_internship_gazebo/src/judge/judge_deviation.hpp
+++ b/h6x_internship_gazebo/src/judge/judge_deviation.hpp
@@ -14,20 +14,21 @@
 
 #pragma once
 
+#include <cv_bridge/cv_bridge.h>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/image.hpp>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <opencv2/opencv.hpp>
-#include <cv_bridge/cv_bridge.h>
 
 #include <std_msgs/msg/bool.hpp>
 
-class JudgeCourseout : public rclcpp::Node
+class JudgeDeviation : public rclcpp::Node
 {
 public:
-  JudgeCourseout();
+  JudgeDeviation();
 
-  void image_callback(const sensor_msgs::msg::Image::ConstSharedPtr & ptr);
+  void onImage(const sensor_msgs::msg::Image::ConstSharedPtr & ptr);
 
 private:
   rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr data_pub_;

--- a/h6x_internship_gazebo/src/judge/judge_goal.hpp
+++ b/h6x_internship_gazebo/src/judge/judge_goal.hpp
@@ -29,28 +29,28 @@ public:
   JudgeGoal();
 
   // データの受信を行うのみ ---------------------------------------------------
-  void start_status_callback(const std_msgs::msg::Bool::SharedPtr ptr);
-  void goal_status_callback(const std_msgs::msg::Bool::SharedPtr ptr);
+  void onStartStatus(const std_msgs::msg::Bool::SharedPtr ptr);
+  void onGoalStatus(const std_msgs::msg::Bool::SharedPtr ptr);
 
   // コースアウト時の挙動
-  void line_courseout_callback(const std_msgs::msg::Bool::SharedPtr ptr);
+  void onLineDeviation(const std_msgs::msg::Bool::SharedPtr ptr);
 
   // timer --------------------------------------------------
   void timer_callback();
 
 private:
   rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr status_pub_;
-  rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr courseout_count_pub_;
+  rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr deviation_count_pub_;
 
   rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr sub_start_;
   rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr sub_goal_;
 
-  rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr sub_courseout_;
+  rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr sub_deviation_;
 
   rclcpp::TimerBase::SharedPtr timer_;
 
   bool started_;
   bool goal_;
 
-  int64_t courseout_count_;
+  int64_t deviation_count_;
 };


### PR DESCRIPTION
- `image_transport`ヘッダーのdeprecation warningを解消
- `courseout`は和製英語なため`deviation`にリネーム
- メソッドの命名規則をGoogle Cording Guideに準拠
- 80文字以上の行に折り返しを追加
- メンバ変数の呼び出しに`this->`ポインタを利用
- そのほかタイポの修正

以上軽微な変更を行いました．基本的な挙動の変更はございません．